### PR TITLE
Replace image tag with v1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   metad0:
-    image: vesoft/nebula-metad:nightly
+    image: vesoft/nebula-metad:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -35,7 +35,7 @@ services:
       - SYS_PTRACE
 
   metad1:
-    image: vesoft/nebula-metad:nightly
+    image: vesoft/nebula-metad:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -69,7 +69,7 @@ services:
       - SYS_PTRACE
 
   metad2:
-    image: vesoft/nebula-metad:nightly
+    image: vesoft/nebula-metad:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -103,7 +103,7 @@ services:
       - SYS_PTRACE
 
   storaged0:
-    image: vesoft/nebula-storaged:nightly
+    image: vesoft/nebula-storaged:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -141,7 +141,7 @@ services:
       - SYS_PTRACE
 
   storaged1:
-    image: vesoft/nebula-storaged:nightly
+    image: vesoft/nebula-storaged:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -179,7 +179,7 @@ services:
       - SYS_PTRACE
 
   storaged2:
-    image: vesoft/nebula-storaged:nightly
+    image: vesoft/nebula-storaged:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -217,7 +217,7 @@ services:
       - SYS_PTRACE
 
   graphd0:
-    image: vesoft/nebula-graphd:nightly
+    image: vesoft/nebula-graphd:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -252,7 +252,7 @@ services:
       - SYS_PTRACE
 
   graphd1:
-    image: vesoft/nebula-graphd:nightly
+    image: vesoft/nebula-graphd:v1
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -287,7 +287,7 @@ services:
       - SYS_PTRACE
 
   graphd2:
-    image: vesoft/nebula-graphd:nightly
+    image: vesoft/nebula-graphd:v1
     environment:
       USER: root
       TZ:   "${TZ}"


### PR DESCRIPTION
Docker image tag nightly now is pointing to v2 nightly version.
For the v1 branch, use image tag v1 which is the same as v1.2.1