### PR TITLE
fix: use fully qualified image names

### DIFF
--- a/docker-compose-lite.yaml
+++ b/docker-compose-lite.yaml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   metad0:
-    image: vesoft/nebula-metad:nightly
+    image: docker.io/vesoft/nebula-metad:nightly
     environment:
       USER: root
     command:
@@ -34,7 +34,7 @@ services:
       - SYS_PTRACE
 
   storaged0:
-    image: vesoft/nebula-storaged:nightly
+    image: docker.io/vesoft/nebula-storaged:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -70,7 +70,7 @@ services:
       - SYS_PTRACE
 
   graphd:
-    image: vesoft/nebula-graphd:nightly
+    image: docker.io/vesoft/nebula-graphd:nightly
     environment:
       USER: root
       TZ:   "${TZ}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   metad0:
-    image: vesoft/nebula-metad:nightly
+    image: docker.io/vesoft/nebula-metad:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -35,7 +35,7 @@ services:
       - SYS_PTRACE
 
   metad1:
-    image: vesoft/nebula-metad:nightly
+    image: docker.io/vesoft/nebula-metad:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -69,7 +69,7 @@ services:
       - SYS_PTRACE
 
   metad2:
-    image: vesoft/nebula-metad:nightly
+    image: docker.io/vesoft/nebula-metad:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -103,7 +103,7 @@ services:
       - SYS_PTRACE
 
   storaged0:
-    image: vesoft/nebula-storaged:nightly
+    image: docker.io/vesoft/nebula-storaged:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -141,7 +141,7 @@ services:
       - SYS_PTRACE
 
   storaged1:
-    image: vesoft/nebula-storaged:nightly
+    image: docker.io/vesoft/nebula-storaged:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -179,7 +179,7 @@ services:
       - SYS_PTRACE
 
   storaged2:
-    image: vesoft/nebula-storaged:nightly
+    image: docker.io/vesoft/nebula-storaged:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -217,7 +217,7 @@ services:
       - SYS_PTRACE
 
   graphd:
-    image: vesoft/nebula-graphd:nightly
+    image: docker.io/vesoft/nebula-graphd:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -253,7 +253,7 @@ services:
       - SYS_PTRACE
 
   graphd1:
-    image: vesoft/nebula-graphd:nightly
+    image: docker.io/vesoft/nebula-graphd:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -289,7 +289,7 @@ services:
       - SYS_PTRACE
 
   graphd2:
-    image: vesoft/nebula-graphd:nightly
+    image: docker.io/vesoft/nebula-graphd:nightly
     environment:
       USER: root
       TZ:   "${TZ}"
@@ -325,7 +325,7 @@ services:
       - SYS_PTRACE
   
   console:
-    image: vesoft/nebula-console:nightly
+    image: docker.io/vesoft/nebula-console:nightly
     entrypoint: ""
     command: 
       - sh


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

* Deployment might pull unintended images
* Deployment gets stuck on systems asking for confirmation of non-qualified images

#### Description:

Using an unqualified image name might yield different results on different systems. The deployment actually relies on docker's default, which is 'docker.io'. Other system might not have this default, and some systems might even pause and interactively ask the user for a decision.

## How do you solve it?

Providing a fully qualified image name solves this issues and ensures that the intended image is pulled.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


