### PR TITLE
make docker-compose-lite.yaml the up and running env

### DIFF
--- a/docker-compose-lite.yaml
+++ b/docker-compose-lite.yaml
@@ -41,7 +41,6 @@ services:
     image: docker.io/vesoft/nebula-storaged:nightly
     environment:
       USER: root
-      TZ:   "${TZ}"
     command:
       - --meta_server_addrs=metad0:9559
       - --local_ip=storaged0
@@ -81,7 +80,6 @@ services:
     image: docker.io/vesoft/nebula-graphd:nightly
     environment:
       USER: root
-      TZ:   "${TZ}"
     command:
       - --meta_server_addrs=metad0:9559
       - --port=9669
@@ -115,20 +113,44 @@ services:
     cap_add:
       - SYS_PTRACE
 
-  console:
+  storage-activator:
+    # This is just a script to activate storaged for the first time run by calling nebula-console
+    # Refer to https://docs.nebula-graph.io/master/4.deployment-and-installation/manage-storage-host/#activate-storaged
+    # If you like to call console via docker, run:
+
+    # docker run --rm -ti --network host vesoft/nebula-console:nightly -addr 127.0.0.1 -port 9669 -u root -p nebula
+
     image: docker.io/vesoft/nebula-console:nightly
     entrypoint: ""
+    environment:
+      ACTIVATOR_RETRY: ${ACTIVATOR_RETRY:-30}
     command: 
       - sh
       - -c
       - |
-        for i in `seq 1 60`;do
-          var=`nebula-console -addr graphd -port 9669 -u root -p nebula -e 'ADD HOSTS "storaged0":9779'`;
-          if [[ $$? == 0 ]];then
+        for i in `seq 1 $$ACTIVATOR_RETRY`; do
+          nebula-console -addr graphd -port 9669 -u root -p nebula -e 'ADD HOSTS "storaged0":9779' 1>/dev/null 2>/dev/null;
+          if [[ $$? == 0 ]]; then
+            echo "✔️ Storage activated successfully.";
+            break;
+          else
+            output=$$(nebula-console -addr graphd -port 9669 -u root -p nebula -e 'ADD HOSTS "storaged0":9779' 2>&1);
+            if echo "$$output" | grep -q "Existed"; then
+              echo "✔️ Storage already activated, Exiting...";
+              break;
+            fi
+          fi;
+          if [[ $$i -lt $$ACTIVATOR_RETRY ]]; then
+            echo "⏳ Attempting to activate storaged, attempt $$i/$$ACTIVATOR_RETRY... It's normal to take some attempts before storaged is ready. Please wait.";
+          else
+            echo "❌ Failed to activate storaged after $$ACTIVATOR_RETRY attempts. Please check MetaD, StorageD logs. Or restart the storage-activator service to continue retry.";
+            echo "ℹ️ Error during storage activation:"
+            echo "=============================================================="
+            echo "$$output"
+            echo "=============================================================="
             break;
           fi;
-          sleep 1;
-          echo "retry to add hosts.";
+          sleep 5;
         done && tail -f /dev/null;
 
     depends_on:

--- a/docker-compose-lite.yaml
+++ b/docker-compose-lite.yaml
@@ -11,7 +11,11 @@ services:
       - --port=9559
       - --ws_http_port=19559
       - --data_path=/data/meta
-      - --log_dir=/logs
+      # - --log_dir=/logs
+      # log to stderr not file
+      - --logtostderr=true
+      - --redirect_stdout=false
+      # log to stderr not file
       - --v=0
       - --minloglevel=0
     healthcheck:
@@ -26,7 +30,7 @@ services:
       - 19560
     volumes:
       - ./data/meta0:/data/meta
-      - ./logs/meta0:/logs
+      # - ./logs/meta0:/logs
     networks:
       - nebula-net
     restart: on-failure
@@ -45,7 +49,11 @@ services:
       - --port=9779
       - --ws_http_port=19779
       - --data_path=/data/storage
-      - --log_dir=/logs
+      # - --log_dir=/logs
+      # log to stderr not file
+      - --logtostderr=true
+      - --redirect_stdout=false
+      # log to stderr not file
       - --v=0
       - --minloglevel=0
     depends_on:
@@ -62,7 +70,7 @@ services:
       - 19780
     volumes:
       - ./data/storage0:/data/storage
-      - ./logs/storage0:/logs
+      # - ./logs/storage0:/logs
     networks:
       - nebula-net
     restart: on-failure
@@ -80,7 +88,11 @@ services:
       - --local_ip=graphd
       - --ws_ip=graphd
       - --ws_http_port=19669
-      - --log_dir=/logs
+      # - --log_dir=/logs
+      # log to stderr not file
+      - --logtostderr=true
+      - --redirect_stdout=false
+      # log to stderr not file
       - --v=0
       - --minloglevel=0
     depends_on:
@@ -95,8 +107,8 @@ services:
       - 9669:9669
       - 19669:19669
       - 19670
-    volumes:
-      - ./logs/graph:/logs
+    # volumes:
+    #   - ./logs/graph:/logs
     networks:
       - nebula-net
     restart: on-failure

--- a/docker-compose-lite.yaml
+++ b/docker-compose-lite.yaml
@@ -103,5 +103,26 @@ services:
     cap_add:
       - SYS_PTRACE
 
+  console:
+    image: docker.io/vesoft/nebula-console:nightly
+    entrypoint: ""
+    command: 
+      - sh
+      - -c
+      - |
+        for i in `seq 1 60`;do
+          var=`nebula-console -addr graphd -port 9669 -u root -p nebula -e 'ADD HOSTS "storaged0":9779'`;
+          if [[ $$? == 0 ]];then
+            break;
+          fi;
+          sleep 1;
+          echo "retry to add hosts.";
+        done && tail -f /dev/null;
+
+    depends_on:
+      - graphd
+    networks:
+      - nebula-net
+
 networks:
   nebula-net:


### PR DESCRIPTION
- the phenomenon before `ADD HOSTS` for fresh users is confusing.
- logging redirect to files is not handy for such cases, we disable it to use stderr instead. (this enables docker logs of all three daemons)

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement
